### PR TITLE
[figma]:update to 0.0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@so.boss/genesis-icon-library",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Icon automation workflow with Figma",
   "main": "dist/index.js",
   "typings": "dist/icons.d.ts",


### PR DESCRIPTION
FIgma groupings are not appened to names of icons